### PR TITLE
proper namespace recording for datastore actions after the namespace has been changed

### DIFF
--- a/src/main/java/com/googlecode/objectify/insight/Recorder.java
+++ b/src/main/java/com/googlecode/objectify/insight/Recorder.java
@@ -70,11 +70,9 @@ public class Recorder {
 	 */
 	public class Batch {
 
-		protected final String namespace;
 		protected final String codePoint;
 
 		Batch() {
-			namespace = NamespaceManager.get();
 			codePoint = codepointer.getCodepoint();
 		}
 
@@ -82,21 +80,21 @@ public class Recorder {
 		 */
 		public void get(Key key) {
 			if (shouldRecord(key.getKind()))
-				collector.collect(bucketFactory.forGet(codePoint, namespace, key.getKind(), 1));
+				collector.collect(bucketFactory.forGet(codePoint, key.getNamespace(), key.getKind(), 1));
 		}
 
 		/**
 		 */
 		public void put(Entity entity) {
 			if (shouldRecord(entity.getKind()))
-				collector.collect(bucketFactory.forPut(codePoint, namespace, entity.getKind(), !entity.getKey().isComplete(), 1));
+				collector.collect(bucketFactory.forPut(codePoint, entity.getNamespace(), entity.getKind(), !entity.getKey().isComplete(), 1));
 		}
 
 		/**
 		 */
 		public void delete(Key key) {
 			if (shouldRecord(key.getKind()))
-				collector.collect(bucketFactory.forDelete(codePoint, namespace, key.getKind(), 1));
+				collector.collect(bucketFactory.forDelete(codePoint, key.getNamespace(), key.getKind(), 1));
 		}
 	}
 
@@ -112,7 +110,7 @@ public class Recorder {
 		 */
 		public void query(Entity entity) {
 			if (shouldRecord(entity.getKind()))
-				collector.collect(bucketFactory.forQuery(codePoint, namespace, entity.getKind(), query, 1));
+				collector.collect(bucketFactory.forQuery(codePoint, entity.getNamespace(), entity.getKind(), query, 1));
 		}
 	}
 }

--- a/src/test/java/com/googlecode/objectify/insight/test/util/TestBase.java
+++ b/src/test/java/com/googlecode/objectify/insight/test/util/TestBase.java
@@ -11,6 +11,7 @@ import com.google.appengine.api.taskqueue.TaskOptions;
 import com.google.appengine.tools.development.testing.LocalDatastoreServiceTestConfig;
 import com.google.appengine.tools.development.testing.LocalServiceTestHelper;
 import com.google.appengine.tools.development.testing.LocalTaskQueueTestConfig;
+import com.google.common.base.Supplier;
 import com.googlecode.objectify.insight.Bucket;
 import com.googlecode.objectify.insight.BucketFactory;
 import com.googlecode.objectify.insight.Clock;
@@ -60,6 +61,18 @@ public class TestBase
 			NamespaceManager.set(namespace);
 
 			runnable.run();
+		} finally {
+			NamespaceManager.set(oldNamespace);
+		}
+	}
+
+	/** */
+	protected <T> T runInNamespace(String namespace, Supplier<T> supplier) {
+		String oldNamespace = NamespaceManager.get();
+		try {
+			NamespaceManager.set(namespace);
+
+			return supplier.get();
 		} finally {
 			NamespaceManager.set(oldNamespace);
 		}


### PR DESCRIPTION
The scenario is the following:

```java
@Entity
@Cache
public class Foo {
	// ...
}
```

```java
NamespaceManager.set("NS1");
Iterable<Foo> iterable = ofy().load().type(Foo.class).iterable();
NamespaceManager.set("NS2");
for (Foo foo : iterable) {
	// ...
}
```

The ```iterable()``` triggered original QUERY action was logged with "NS1" namespace - as expected -, but the following GET actions executed by hybrid queries wasn't. It was recorded as "NS2", despite returning entities from the previous namespace. This fix solves this issue.