### PR TITLE
Group the datastore operations by module and version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -176,7 +176,7 @@
 		<dependency>
 			<groupId>com.google.apis</groupId>
 			<artifactId>google-api-services-bigquery</artifactId>
-			<version>v2-rev163-1.19.0</version>
+			<version>v2-rev337-1.22.0</version>
 		</dependency>
 
 		<!-- Google App Engine -->

--- a/src/main/java/com/googlecode/objectify/insight/BucketFactory.java
+++ b/src/main/java/com/googlecode/objectify/insight/BucketFactory.java
@@ -1,7 +1,12 @@
 package com.googlecode.objectify.insight;
 
 import lombok.Data;
+
+import javax.annotation.Nullable;
 import javax.inject.Inject;
+import javax.inject.Named;
+
+import com.google.appengine.api.modules.ModulesServiceFactory;
 
 /**
  * Buckets are given a timestamp that depends on a configurable value, so we need to
@@ -12,38 +17,42 @@ public class BucketFactory {
 
 	/** Gives us rounded timestamps */
 	private final Clock clock;
+	private final String module;
+	private final String version;
 
 	public BucketFactory() {
-		this(new Clock());
+		this(new Clock(), ModulesServiceFactory.getModulesService().getCurrentModule(), ModulesServiceFactory.getModulesService().getCurrentVersion());
 	}
 
 	@Inject
-	public BucketFactory(Clock clock) {
+	public BucketFactory(Clock clock, @Named("module") String module, @Named("version") String version) {
 		this.clock = clock;
+		this.module = module;
+		this.version = version;
 	}
 
 	/**
 	 */
 	public Bucket forGet(String codePoint, String namespace, String kind, long readCount) {
-		return new Bucket(new BucketKey(codePoint, namespace, kind, Operation.GET, null, clock.getTime()), readCount, 0);
+		return new Bucket(new BucketKey(codePoint, namespace, module, version, kind, Operation.GET, null, clock.getTime()), readCount, 0);
 	}
 
 	/**
 	 */
 	public Bucket forPut(String codePoint, String namespace, String kind, boolean insert, long writeCount) {
 		Operation op = insert ? Operation.INSERT : Operation.UPDATE;
-		return new Bucket(new BucketKey(codePoint, namespace, kind, op, null, clock.getTime()), 0, writeCount);
+		return new Bucket(new BucketKey(codePoint, namespace, module, version, kind, op, null, clock.getTime()), 0, writeCount);
 	}
 
 	/**
 	 */
 	public Bucket forDelete(String codePoint, String namespace, String kind, long writeCount) {
-		return new Bucket(new BucketKey(codePoint, namespace, kind, Operation.DELETE, null, clock.getTime()), 0, writeCount);
+		return new Bucket(new BucketKey(codePoint, namespace, module, version, kind, Operation.DELETE, null, clock.getTime()), 0, writeCount);
 	}
 
 	/**
 	 */
 	public Bucket forQuery(String codePoint, String namespace, String kind, String queryString, long readCount) {
-		return new Bucket(new BucketKey(codePoint, namespace, kind, Operation.QUERY, queryString, clock.getTime()), readCount, 0);
+		return new Bucket(new BucketKey(codePoint, namespace, module, version, kind, Operation.QUERY, queryString, clock.getTime()), readCount, 0);
 	}
 }

--- a/src/main/java/com/googlecode/objectify/insight/BucketKey.java
+++ b/src/main/java/com/googlecode/objectify/insight/BucketKey.java
@@ -14,6 +14,8 @@ import lombok.NoArgsConstructor;
 public class BucketKey {
 	private String codepoint;
 	private String namespace;
+	private String module;
+	private String version;
 	private String kind;
 	private Operation op;
 	private String query;

--- a/src/main/java/com/googlecode/objectify/insight/puller/BigUploader.java
+++ b/src/main/java/com/googlecode/objectify/insight/puller/BigUploader.java
@@ -44,6 +44,8 @@ public class BigUploader {
 			row.set("uploaded", System.currentTimeMillis() / 1000f);	// unix timestamp
 			row.set("codepoint", bucket.getKey().getCodepoint());
 			row.set("namespace", bucket.getKey().getNamespace());
+			row.set("module", bucket.getKey().getModule());
+			row.set("version", bucket.getKey().getVersion());
 			row.set("kind", bucket.getKey().getKind());
 			row.set("op", bucket.getKey().getOp());
 			row.set("query", bucket.getKey().getQuery());
@@ -64,6 +66,7 @@ public class BigUploader {
 		}
 
 		TableDataInsertAllRequest request = new TableDataInsertAllRequest().setRows(rows);
+		request.setIgnoreUnknownValues(true);
 
 		String tableId = tablePicker.pick();
 

--- a/src/main/java/com/googlecode/objectify/insight/puller/TablePicker.java
+++ b/src/main/java/com/googlecode/objectify/insight/puller/TablePicker.java
@@ -102,6 +102,8 @@ public class TablePicker {
 		fields.add(tableFieldSchema("uploaded", "TIMESTAMP"));
 		fields.add(tableFieldSchema("codepoint", "STRING"));
 		fields.add(tableFieldSchema("namespace", "STRING"));
+		fields.add(tableFieldSchema("module", "STRING"));
+		fields.add(tableFieldSchema("version", "STRING"));
 		fields.add(tableFieldSchema("kind", "STRING"));
 		fields.add(tableFieldSchema("op", "STRING"));
 		fields.add(tableFieldSchema("query", "STRING"));

--- a/src/test/java/com/googlecode/objectify/insight/test/InsightCollectorTimeTest.java
+++ b/src/test/java/com/googlecode/objectify/insight/test/InsightCollectorTimeTest.java
@@ -29,7 +29,7 @@ public class InsightCollectorTimeTest extends TestBase {
 	public void setUpFixture() throws Exception {
 		when(clock.getTime()).thenReturn(100L, 200L);
 
-		bucketFactory = new BucketFactory(clock);
+		bucketFactory = new BucketFactory(clock, "module", "version");
 		collector = new Collector(flusher);
 	}
 

--- a/src/test/java/com/googlecode/objectify/insight/test/util/TestBase.java
+++ b/src/test/java/com/googlecode/objectify/insight/test/util/TestBase.java
@@ -111,7 +111,7 @@ public class TestBase
 	protected BucketFactory constantTimeBucketFactory() {
 		Clock clock = mock(Clock.class);
 		when(clock.getTime()).thenReturn(100L);	// just a stable value
-		return new BucketFactory(clock);
+		return new BucketFactory(clock, "module", "version");
 	}
 
 }


### PR DESCRIPTION
I use objectify-insight in an application with a lot of modules and versions. 
At the moment I don't have a good way to tell which modules use datastore the most and how a new version changes the datastore usage pattern during a progressive roll out.

This change adds the module and version to the BucketKey. This automatically partitions the data,

I upgraded the big query client library so I can use the ignoreUnknownValues flag. 
This is important otherwise BQ inserts with these new fields would fail until a new table is generated by the cron.

Those who use guice need to register the module and version named properties for the injection to work properly.